### PR TITLE
Fix documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Changes
 This fork adds the ability to add attributes to soap envelope and header elements.
 
-###Add attributes
+##Add attributes
 Define your attributes as an array of type `{ns:String, nsUri:String}`.
-`client.addEnvelopeAttributes([{ns:'xmlns:mha',nsUri:'https://my.uri.value'])`
-`client.addHeaderAttributes([{ns:'xmlns:mha',nsUri:'https://my.uri.value'])`
+`client.addEnvelopeAttributes([{ns:'xmlns:mha',nsUri:'https://my.uri.value'}])`
+`client.addHeaderAttributes([{ns:'xmlns:mha',nsUri:'https://my.uri.value'}])`
 
 
 # strong-soap


### PR DESCRIPTION
Fixes the syntax error in documentation examples for setHeaderAttributes and setEnvelopeAttributes.
